### PR TITLE
Dropping unique param.

### DIFF
--- a/src/wagtailimagecaptions/migrations/0005_auto_20231121_1134.py
+++ b/src/wagtailimagecaptions/migrations/0005_auto_20231121_1134.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="captionedimage",
             name="uuid",
-            field=models.UUIDField(db_index=True, default=uuid.uuid4, editable=False, unique=True),
+            field=models.UUIDField(db_index=True, default=uuid.uuid4, editable=False),
         ),
     ]


### PR DESCRIPTION
This PR drops an errant `unique=True` parameter in a migration file.