### PR TITLE
Bugfix for rich text field output in admin templates.

### DIFF
--- a/src/wagtailimagecaptions/__init__.py
+++ b/src/wagtailimagecaptions/__init__.py
@@ -3,4 +3,4 @@ A Django app for extending the Wagtail Image model to add captions and alt field
 well as the extraction of IPTC image meta data.
 """
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/src/wagtailimagecaptions/signals.py
+++ b/src/wagtailimagecaptions/signals.py
@@ -48,6 +48,9 @@ def parse_image_meta(sender, **kwargs):
         else:
             instance.caption = linebreaks(caption.strip())
 
+        # Wagtail complains about <br> tags in <p> tags.
+        instance.caption = re.sub(r"<br\s*>", "<br />", instance.caption, flags=re.IGNORECASE)
+
     if byline := meta_dict.get("byline", ""):
         trimmed_byline = Truncator(byline.strip()).chars(255)
         instance.byline = trimmed_byline


### PR DESCRIPTION
This PR changes the following:

- Converts `<br>` to `<br />` for Wagtail rich text field output in admin templates that use the `fomattedfield` tag.